### PR TITLE
[2] Implement healthcheck endpoint and conditional start

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -30,6 +30,12 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
+# bundle the statically compiled grpc-health-probe
+RUN apt-get update && apt-get -y install lsof wget
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.13 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
+
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
 # Leverage a bind mount to requirements.txt to avoid having to copy them into

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 grpcio==1.63.0
+grpcio_health_checking==1.63.0
 grpcio_reflection==1.63.0
 protobuf==5.26.1
 psycopg[binary]==3.1.19

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,13 +19,25 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/bin/grpc_health_probe",
+          "-addr=localhost:50051"
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   client:
     build:
       context: app
     command: python3 /app/budgeter_client.py
     depends_on:
-      - server
+      server:
+        condition: service_healthy
     restart: on-failure:3
 
   db:


### PR DESCRIPTION
# Overview
Adds a healthcheck endpoint to the Budgeter server. The healthcheck is registered in reflection, so that it shows up when listed. This uses gRPC's standard service API ([health/v1](https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto)). 
- Using `grpc_health_probe` tool to query this healthcheck endpoint, we specify it as the server's `HEALTHCHECK` condition in the compose file.
- In the compose file we also make this healthiness a condition before starting the client. This stops the extra error as the client prematurely hits the server's endpoints. 
- The client also calls the healthcheck endpoint

Closes #4
# Test
```
docker pull fullstorydev/grpcurl
docker run --network=budgeter_default fullstorydev/grpcurl  -plaintext server:50051 grpc.health.v1.Health/Check
```